### PR TITLE
Remove conflicting import

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgCite"
 uuid = "50d0efc5-baaf-4329-a409-faca2d9bd902"
 authors = ["Sebastian Micluța-Câmpeanu <m.c.sebastian95@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 BibParser = "13533e5b-e1c2-4e57-8cef-cac5e52f6474"

--- a/src/PkgCite.jl
+++ b/src/PkgCite.jl
@@ -1,6 +1,5 @@
 module PkgCite
 
-using Pkg: include
 using DataStructures: getkey, values
 using Base: String
 export get_citations, get_tool_citation


### PR DESCRIPTION
This PR fixes the following warning for me:
```julia
julia> using PkgCite
WARNING: import of Pkg.include into PkgCite conflicts with an existing identifier; ignored.
```