### PR TITLE
Add CFF support to PkgCite using Bibliography.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Manifest.toml
 # Test-generated files
 test/**/Manifest.toml
 test/julia_citations.bib
+test/converted_citation.cff

--- a/Project.toml
+++ b/Project.toml
@@ -12,12 +12,14 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 BibParser = "0.1, 0.2"
 Bibliography = "0.2, 0.3"
 DataStructures = "0.18, 0.19"
 HTTP = "0.9, 1"
+YAML = "0.4"
 julia = "1.6"
 
 [extras]

--- a/src/PkgCite.jl
+++ b/src/PkgCite.jl
@@ -7,11 +7,13 @@ export get_citations, get_tool_citation
 import Pkg
 import TOML
 using Bibliography: import_bibtex, export_bibtex, Entry
+using Bibliography: BibInternal
 using DataStructures
 using InteractiveUtils
 using BibParser: parse_entry
+using Dates
 using HTTP
-using Dates: year, today
+using YAML
 
 const DEFAULT_CITE = "\\cite"
 

--- a/src/citations.jl
+++ b/src/citations.jl
@@ -1,31 +1,95 @@
 function citation_path(pkg)
+    # Check for CITATION.cff first (preferred format)
+    cff_path = joinpath(pkg.source, "CITATION.cff")
+    if isfile(cff_path)
+        return (cff_path, :cff)
+    end
+
+    # Fall back to CITATION.bib
     bib_path = joinpath(pkg.source, "CITATION.bib")
     if isfile(bib_path)
-        bib_path
+        return (bib_path, :bib)
     end
+
+    return nothing
 end
 
+"""
+    parse_cff(filepath::AbstractString, key::AbstractString)
+
+Parse a CITATION.cff file and return a `BibInternal.Entry`.
+Uses `preferred-citation` if present, otherwise top-level metadata.
+"""
+function parse_cff(filepath::AbstractString, key::AbstractString)
+    cff = YAML.load_file(filepath)
+
+    # Use preferred-citation if available, otherwise top-level
+    data = get(cff, "preferred-citation", cff)
+
+    # Build BibTeX-style author string: "Given Family and Given Family"
+    authors_list = get(data, "authors", get(cff, "authors", []))
+    author_strs = String[]
+    for a in authors_list
+        given = get(a, "given-names", "")
+        family = get(a, "family-names", "")
+        push!(author_strs, strip("$given $family"))
+    end
+    author_str = join(author_strs, " and ")
+
+    entry_type = get(data, "type", "software")
+    fields = Dict{String,String}("_type" => entry_type, "author" => author_str)
+
+    haskey(data, "title") && (fields["title"] = string(data["title"]))
+    haskey(data, "doi") && (fields["doi"] = string(data["doi"]))
+    haskey(data, "url") && (fields["url"] = string(data["url"]))
+    !haskey(fields, "url") && haskey(data, "repository-code") && (fields["url"] = string(data["repository-code"]))
+    haskey(data, "journal") && (fields["journal"] = string(data["journal"]))
+    haskey(data, "volume") && (fields["volume"] = string(data["volume"]))
+    haskey(data, "issue") && (fields["number"] = string(data["issue"]))
+
+    if haskey(data, "date-released")
+        d = data["date-released"]
+        if d isa Dates.Date
+            fields["year"] = string(Dates.year(d))
+        else
+            # Try to extract year from string like "2024-01-15"
+            m = match(r"^(\d{4})", string(d))
+            !isnothing(m) && (fields["year"] = m.captures[1])
+        end
+    elseif haskey(data, "year")
+        fields["year"] = string(data["year"])
+    end
+
+    return BibInternal.Entry(key, fields)
+end
 
 # Added `badge` flag to avoid breaking current tests
 # Added `fallback` flag to generate citations from Project.toml metadata
 function get_citation(pkg; badge=false, fallback=false)
-    bib_path = citation_path(pkg)
+    citation_info = citation_path(pkg)
     if badge == false
         urlbadge = nothing
     else
         urlbadge = get_badge(pkg)
     end
-    if !isnothing(bib_path)
-        @debug "Reading CITATION.bib for $(pkg.name)"
+    if !isnothing(citation_info)
+        citation_file, format = citation_info
+        @debug "Reading $(format == :cff ? "CITATION.cff" : "CITATION.bib") for $(pkg.name)"
         try
-            bib = import_bibtex(bib_path, check=:warn)
-            if isempty(bib)
-                @warn "The CITATION.bib file for $(pkg.name) is empty."
+            if format == :cff
+                entry = parse_cff(citation_file, pkg.name)
+                bib = DataStructures.OrderedDict{String, Entry}(pkg.name => entry)
+                return bib
+            else
+                bib = import_bibtex(citation_file, check=:warn)
+                if isempty(bib)
+                    @warn "The CITATION.bib file for $(pkg.name) is empty."
+                end
+                return bib
             end
-
-            bib
         catch e
-            @warn "There was an error reading the CITATION.bib file for $(pkg.name)" exception=e
+            format_name = format == :cff ? "CITATION.cff" : "CITATION.bib"
+            @warn "There was an error reading the $format_name file for $(pkg.name)" exception=e
         end
     elseif !isnothing(urlbadge)
         get_citation_badge(urlbadge)
@@ -234,3 +298,4 @@ function get_badge(pkg)
     end
     return nothing
 end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using PkgCite
-using PkgCite: collect_citations, bibliography, cited_packages, make_sentence, generate_fallback_citation
+using PkgCite: collect_citations, bibliography, cited_packages, make_sentence, generate_fallback_citation, parse_cff
 using InteractiveUtils
 using Bibliography
 using Test
@@ -90,12 +90,15 @@ end
     @testset "Only direct dependencies" begin
         citations = collect_citations(true)
         pkgs = cited_packages(citations)
-        @test only(pkgs) == "Symbolics"
+        @test "Symbolics" ∈ pkgs
+        # ArnoldiMethod has a CITATION.cff (v1.2.0), testing end-to-end CFF support
+        @test "ArnoldiMethod" ∈ pkgs
 
         # Test sentence structure without hard-coding exact citation keys
         sentence = make_sentence(citations)
         @test occursin("Julia v$VERSION", sentence)
         @test occursin("Symbolics.jl", sentence)
+        @test occursin("ArnoldiMethod.jl", sentence)
         @test occursin("\\cite", sentence)
 
         sentence_tt = make_sentence(citations, texttt=true)
@@ -211,6 +214,44 @@ end
         catch e
             @warn "Skipping fallback environment tests due to instantiation error" exception=(e, catch_backtrace())
             @test_skip false
+        end
+    end
+
+    @testset "CFF Support" begin
+        # Switch back to test_env which has ArnoldiMethod (CITATION.cff v1.2.0)
+        Pkg.activate(test_env)
+
+        @testset "parse_cff" begin
+            # Test parse_cff directly on ArnoldiMethod's CITATION.cff
+            arnoldi_pkg = first(pkg for pkg in values(Pkg.dependencies()) if pkg.name == "ArnoldiMethod")
+            cff_path = joinpath(arnoldi_pkg.source, "CITATION.cff")
+            entry = parse_cff(cff_path, "ArnoldiMethod")
+            @test entry isa Bibliography.Entry
+            @test occursin("Arnoldi", entry.title)
+            @test !isempty(entry.authors)
+        end
+
+        @testset "CFF file detection" begin
+            using PkgCite: citation_path
+
+            # ArnoldiMethod has CITATION.cff but no CITATION.bib
+            arnoldi_pkg = first(pkg for pkg in values(Pkg.dependencies()) if pkg.name == "ArnoldiMethod")
+            result = citation_path(arnoldi_pkg)
+            @test !isnothing(result)
+            path, format = result
+            @test format == :cff
+            @test endswith(path, "CITATION.cff")
+        end
+
+        @testset "CFF citation collected" begin
+            # Verify ArnoldiMethod is collected through the full pipeline
+            citations = collect_citations(true)
+            @test haskey(citations, "ArnoldiMethod")
+            bib = citations["ArnoldiMethod"]
+            @test !isempty(bib)
+            entry = first(values(bib))
+            @test entry isa Bibliography.Entry
+            @test occursin("Arnoldi", entry.title)
         end
     end
 end

--- a/test/test_env/Project.toml
+++ b/test/test_env/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"


### PR DESCRIPTION
## Summary
- Add support for reading CITATION.cff files (Citation File Format) using a custom YAML-based parser
- CITATION.cff is checked first, falling back to CITATION.bib
- Parses CFF metadata (authors, title, DOI, URL, date, journal, etc.) into `BibInternal.Entry` objects
- Supports both `preferred-citation` and top-level CFF metadata
- Handles `date-released` as both `Dates.Date` and string formats
- Falls back to `repository-code` when `url` is not present
- Tests use real package (ArnoldiMethod v0.4.0 with CITATION.cff) for end-to-end validation

### Why a custom parser?
BibParser.jl's `import_cff` is broken for real-world CFF files:
- Fails on CFF v1.1.0 (`UnsupportedCFFVersion`)
- Fails on v1.2.0 without `preferred-citation` (`UndefVarError(:current_id)`)

Instead, we parse CFF files directly with YAML.jl (already a transitive dependency) and construct `BibInternal.Entry` objects, which is the same type used throughout the Bibliography.jl ecosystem.

### New dependency
- YAML.jl (already a transitive dep via BibParser, so no new install)
- Dates stdlib (for parsing `date-released` fields)

## Test plan
- [x] `parse_cff` correctly parses ArnoldiMethod's real CITATION.cff
- [x] CFF file detection prefers `.cff` over `.bib`
- [x] CFF citations flow through full pipeline (collect → bibliography → sentence → export)
- [x] ArnoldiMethod appears in `cited_packages` and `make_sentence` output
- [x] Badge environment tests still pass (WriteVTK with CFF is now parsed by our parser)
- [x] All 40 tests pass, 2 broken (expected: Distributions bib error, @software entry type)
- [x] Tests pass locally on Julia 1.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)