### PR TITLE
Add optional fallback for package citation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,9 +7,11 @@ version = "0.1.3"
 BibParser = "13533e5b-e1c2-4e57-8cef-cac5e52f6474"
 Bibliography = "f1be7e48-bf82-45af-a471-ae754a193061"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 BibParser = "0.1, 0.2"

--- a/src/PkgCite.jl
+++ b/src/PkgCite.jl
@@ -5,11 +5,13 @@ using Base: String
 export get_citations, get_tool_citation
 
 import Pkg
+import TOML
 using Bibliography: import_bibtex, export_bibtex, Entry
 using DataStructures
 using InteractiveUtils
 using BibParser: parse_entry
 using HTTP
+using Dates: year, today
 
 const DEFAULT_CITE = "\\cite"
 

--- a/src/citations.jl
+++ b/src/citations.jl
@@ -178,13 +178,8 @@ function generate_fallback_citation(pkg)
         end
     end
 
-    # Get URL from repo or construct from package name
-    url = if haskey(project, "repo")
-        project["repo"]
-    else
-        # Try common Julia package URL patterns
-        "https://github.com/JuliaPackages/$(name).jl"
-    end
+    # Get URL from package's git source (from Manifest.toml)
+    url = pkg.git_source
 
     # Format authors for BibTeX (Last, First and Last, First format)
     authors_str = if isempty(authors)
@@ -197,13 +192,13 @@ function generate_fallback_citation(pkg)
     current_year = year(today())
     citation_key = "$(name)_jl_$(current_year)"
 
-    # Create BibTeX entry
+    # Create BibTeX entry (only include url if available)
+    url_line = isnothing(url) ? "" : "\n      url = {$url},"
     bibtex = """
     @misc{$citation_key,
       author = {$authors_str},
       title = {$name.jl},
-      year = {$current_year},
-      url = {$url},
+      year = {$current_year},$url_line
       note = {Julia package version $version}
     }
     """

--- a/src/tool_report.jl
+++ b/src/tool_report.jl
@@ -55,7 +55,7 @@ function make_sentence(pkg_citations; cite_commands=Dict{String,String}(), jl=tr
 end
 
 """
-    get_tool_citation(io::IO=stdout; jl = true, texttt = false, copy = true, cite_commands=Dict{String,String}(), filename="julia_citations.bib", badge=false)
+    get_tool_citation(io::IO=stdout; jl = true, texttt = false, copy = true, cite_commands=Dict{String,String}(), filename="julia_citations.bib", badge=false, fallback=false)
 
 Print a sentence describing the packages used in the current environment.
 If you only want to consider the direct dependencies, you can set `only_direct=true`.
@@ -65,7 +65,10 @@ Package names can be wrapped in `texttt` by setting `texttt=true` and you can al
 the cite command used for each package by using `cite_commands=Dict("PackageName"=>"custom_cite")`.
 The filename of the .bib file can be passed via the `filename` keyword.
 Use `badge = true` to get the citations from packages without
-a `Citation.bib` file, but with a DOI badge.
+a `CITATION.bib` file, but with a DOI badge.
+Use `fallback = true` to generate citations from `Project.toml` metadata
+for packages without a `CITATION.bib` file or DOI badge. This can be noisy
+in large environments, so it is disabled by default.
 """
 function get_tool_citation(io::IO=stdout;
     jl = true,
@@ -74,9 +77,10 @@ function get_tool_citation(io::IO=stdout;
     only_direct = false,
     cite_commands=Dict{String,String}(),
     filename="julia_citations.bib",
-    badge=false)
+    badge=false,
+    fallback=false)
 
-    pkg_citations = collect_citations(only_direct, badge=badge)
+    pkg_citations = collect_citations(only_direct, badge=badge, fallback=fallback)
 
     cite_sentence = make_sentence(pkg_citations; cite_commands, jl, texttt)
     println(io, cite_sentence)

--- a/test/fallback_env/Project.toml
+++ b/test/fallback_env/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"


### PR DESCRIPTION
Implements a fallback mechanism for packages without CITATION.bib files, as requested in issue #24. When `fallback=true` is passed to get_citations(), get_tool_citation(), or collect_citations(), the package will generate citations from Project.toml metadata for packages that lack both a CITATION.bib file and a DOI badge.

The fallback extracts:
- Authors from the `authors` field (with email stripping)
- Package name and version
- Repository URL

The fallback is disabled by default to avoid being noisy in large environments with many dependencies.